### PR TITLE
Test mode

### DIFF
--- a/bin/composer-cleaner.php
+++ b/bin/composer-cleaner.php
@@ -7,5 +7,7 @@ set_exception_handler(function($e) {
 	exit(1);
 });
 
-$cleaner = new Cleaner;
-$cleaner->clean(isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : getcwd());
+$argv = array_slice($_SERVER['argv'], 1); // indexed from 0
+
+$cleaner = new Cleaner($testMode = isset($argv[0]) && ($argv[0] === '-t' || $argv[0] === '--test'));
+$cleaner->clean(isset($argv[0]) && !$testMode ? $argv[0] : (isset($argv[1]) ? $argv[1] : getcwd()));

--- a/src/Cleaner.php
+++ b/src/Cleaner.php
@@ -11,19 +11,31 @@ class Cleaner
 {
 	/** @var int */
 	private $removedCount;
+	
+	/** @var bool */
+	private $testMode = false;
 
+
+	/**
+	 * @param bool whether to run in test mode (just show what would be done)
+	 */
+	public function __construct($testMode = false) {
+		$this->testMode = $testMode;
+	}
 
 	/**
 	 * @return void
 	 */
 	public function clean($projectDir)
 	{
+		if($this->testMode) echo "Running in test mode.\n";
+		
 		$this->removedCount = 0;
 		$data = $this->loadComposerJson($projectDir);
 		$vendorDir = isset($data->config->{'vendor-dir'}) ? $data->config->{'vendor-dir'} : 'vendor';
 		$this->processVendorDir("$projectDir/$vendorDir");
 
-		echo "Removed $this->removedCount files.\n";
+		echo "\nRemoved $this->removedCount files.\n";
 	}
 
 	/**
@@ -80,7 +92,7 @@ class Cleaner
 			$fileName = $path->getFileName();
 			if (!isset($dirs[$fileName]) && strncasecmp($fileName, 'license', 7)) {
 				echo "deleting $fileName\n";
-				$this->delete($path);
+				!$this->testMode && $this->delete($path);
 			}
 		}
 	}


### PR DESCRIPTION
Allow users to preview what would be done by entering a _test mode_.

Test mode is disabled by default, but can be enabled adding flag `-t` or `--test` as the first executable's argument. It can be also enabled by setting the first argument of `Cleaner::__construct( boolean )` to `true`.

Implementation summary:
- add `$testMode` parameter to the `Cleaner::__construct( boolean )` signature
- force `-t | --test` to be the first argument of executable, but keep BC
