### PR TITLE
Allow cleaner to be installed and use like a normal composer pkg

### DIFF
--- a/src/Composer/Cleaner.php
+++ b/src/Composer/Cleaner.php
@@ -1,5 +1,13 @@
 <?php
 
+namespace DGComposer;
+
+use Exception;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use stdClass;
+
 /**
  * Victor The Cleaner for Composer.
  *

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,14 +1,12 @@
 <?php
 
-require is_file(__DIR__ . '/../vendor/autoload.php')
-	? __DIR__ . '/../vendor/autoload.php'
-	: __DIR__ . '/../../../autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
+} else {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
 
-
-set_exception_handler(function($e) {
-	echo "ERROR: {$e->getMessage()}\n";
-	exit(1);
-});
+use DGComposer\Cleaner;
 
 
 $cmd = new Nette\CommandLine\Parser(<<<XX


### PR DESCRIPTION
You can then simply run `php vendor/bin/composer-cleaner --test` which
can then be run as part of a standard deploy procedure. Namespaced as
`DGComposer` to avoid confusion and affiliation with Composer itself.

A second set of eyes and some testing would be great here. Thanks.