### PR TITLE
Ignoring whole packages, better output distinction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,3 +32,17 @@ You can also specify paths to be ignored via `composer.json`:
 	}
 }
 ```
+
+or you can ignore the whole package:
+
+```js
+{
+	"extra": {
+		"cleaner-ignore": {
+			"slevomat/eet-client": [  // name of package
+				"*"                // ignore all
+			]
+		}
+	}
+}
+```

--- a/src/ComposerCleaner/Cleaner.php
+++ b/src/ComposerCleaner/Cleaner.php
@@ -51,11 +51,11 @@ class Cleaner
 				}
 				$name = $packageVendor->getFileName() . '/' . $packageName->getFileName();
 				$ignore = isset($ignorePaths[$name]) ? (array) $ignorePaths[$name] : [];
-				$this->io->write("Package $name", true, IOInterface::VERBOSE);
+				$this->io->write("Composer cleaner: Package $name", true, IOInterface::VERBOSE);
 				$this->processPackage((string) $packageName, $ignore);
 			}
 		}
-		$this->io->write("Removed $this->removedCount files or directories.");
+		$this->io->write("Composer cleaner: Removed $this->removedCount files or directories.");
 	}
 
 
@@ -76,7 +76,7 @@ class Cleaner
 			$dir = trim(ltrim($exclude, '.'), '/');
 			if ($dir && strpos($dir, '..') === false && !isset($paths[$dir])) {
 				$path = $packageDir . '/' . $dir;
-				$this->io->write("Removing $path", true, IOInterface::VERBOSE);
+				$this->io->write("Composer cleaner: Removing $path", true, IOInterface::VERBOSE);
 				$this->fileSystem->remove($path);
 				$this->removedCount++;
 			}
@@ -96,7 +96,7 @@ class Cleaner
 		foreach (new FileSystemIterator($packageDir) as $path) {
 			$fileName = $path->getFileName();
 			if (!isset($paths[$fileName]) && strncasecmp($fileName, 'license', 7)) {
-				$this->io->write("Removing $path", true, IOInterface::VERBOSE);
+				$this->io->write("Composer cleaner: Removing $path", true, IOInterface::VERBOSE);
 				$this->fileSystem->remove($path);
 				$this->removedCount++;
 			}
@@ -163,12 +163,12 @@ class Cleaner
 	{
 		$file = $dir . '/composer.json';
 		if (!is_file($file)) {
-			$this->io->writeError("File $file not found.", true, IOInterface::VERBOSE);
+			$this->io->writeError("Composer cleaner: File $file not found.", true, IOInterface::VERBOSE);
 			return;
 		}
 		$data = json_decode(file_get_contents($file));
 		if (!$data instanceof stdClass) {
-			$this->io->writeError("Invalid $file.");
+			$this->io->writeError("Composer cleaner: Invalid $file.");
 			return;
 		}
 		return $data;

--- a/src/ComposerCleaner/Cleaner.php
+++ b/src/ComposerCleaner/Cleaner.php
@@ -72,6 +72,11 @@ class Cleaner
 
 		$paths = array_fill_keys($ignorePaths, true);
 
+		if (isset($paths['*'])) {
+			$this->io->write("Composer cleaner: Ignoring whole package $packageDir", true, IOInterface::VERBOSE);
+			return;
+		}
+
 		foreach ($this->getExcludes($data) as $exclude) {
 			$dir = trim(ltrim($exclude, '.'), '/');
 			if ($dir && strpos($dir, '..') === false && !isset($paths[$dir])) {

--- a/tests/Cleaner.loadComposerJson.phpt
+++ b/tests/Cleaner.loadComposerJson.phpt
@@ -17,5 +17,5 @@ Assert::same([], $io->getLog());
 Assert::null($cleaner->loadComposerJson(__DIR__ . '/not-exists'));
 Assert::same([[
 	'writeError',
-	['File ' . __DIR__ . '/not-exists/composer.json not found.', true, IOInterface::VERBOSE],
+	['Composer cleaner: File ' . __DIR__ . '/not-exists/composer.json not found.', true, IOInterface::VERBOSE],
 ]], $io->getLog());


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? maybe?

- The ignoring fourliner makes easier to ignore a whole package with assets in root ([see this SO QA](https://stackoverflow.com/questions/46195321/composer-removing-random-files-from-package-after-installation/46212934#46212934))
- The output prefixes makes distinction of the origin output clearer