### PR TITLE
fix cleaner-ignore example for whole package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,9 @@ Simply add a `extra > cleaner-ignore` section to `composer.json` file:
 				"wsdl*"               // list of files or subdirectories, you can use wildcards `*` and `?`
 			],
 
-			"mpdf/mpdf": true         // ignores whole package
+			"mpdf/mpdf": [
+				""      	   // ignores whole package
+			]
 		}
 	}
 }


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

The README.MD example for ignoring whole package doesn't work.
true does nothing; [""] works as suggested here:
https://forum.nette.org/cs/29055-mpdf-problem-so-spustenim#p189907