### PR TITLE
fix: cast SplFileInfo to string for FilesystemIterator constructor

### DIFF
--- a/src/ComposerCleaner/Cleaner.php
+++ b/src/ComposerCleaner/Cleaner.php
@@ -49,7 +49,7 @@ class Cleaner
 			if (!$packageVendor->isDir()) {
 				continue;
 			}
-			foreach (new FilesystemIterator($packageVendor) as $packageName) {
+			foreach (new FilesystemIterator((string) $packageVendor) as $packageName) {
 				if (!$packageName->isDir()) {
 					continue;
 				}


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

When I try to use this plugin within my CI/CD I get the following error:

```
Fatal error: Uncaught TypeError: FilesystemIterator::__construct() expects parameter 1 to be a valid path, object given in /tmp/builds/devowlio/devowl-wp/plugins/real-media-library/vendor/dg/composer-cleaner/src/ComposerCleaner/Cleaner.php:53
Stack trace:
#0 /tmp/builds/devowlio/devowl-wp/plugins/real-media-library/vendor/dg/composer-cleaner/src/ComposerCleaner/Cleaner.php(53): FilesystemIterator->__construct(Object(SplFileInfo))
#1 /tmp/builds/devowlio/devowl-wp/plugins/real-media-library/vendor/dg/composer-cleaner/src/ComposerCleaner/Plugin.php(40): DG\ComposerCleaner\Cleaner->clean('/tmp/builds/dev...', Array)
#2 [internal function]: DG\ComposerCleaner\Plugin->clean(Object(Composer\Script\Event))
#3 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Composer\Script\Event))
#4 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(96): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Script\Event))
#5 phar:///usr in /tmp/builds/devowlio/devowl-wp/plugins/real-media-library/vendor/dg/composer-cleaner/src/ComposerCleaner/Cleaner.php on line 53
```

This happens because [`FilesystemIterator::__construct`](https://www.php.net/manual/en/filesystemiterator.construct.php) expects a `string` as `$path` parameter.

**Solution:**

Use `strval` to cast `SplFileInfo` to an absolute path string.

**Environment:**

```
$ composer --version
Composer version 1.10.7 2020-06-03 10:03:56
$ php -v
PHP 7.3.18 (cli) (built: May 15 2020 13:51:16) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.18, Copyright (c) 1998-2018 Zend Technologies
```

**No tests added**