### PR TITLE
fix: cast SplFileInfo to string for Composer\Util\Filesystem::remove()

### DIFF
--- a/src/ComposerCleaner/Cleaner.php
+++ b/src/ComposerCleaner/Cleaner.php
@@ -97,7 +97,7 @@ class Cleaner
 			$fileName = $path->getFileName();
 			if (!self::matchMask($fileName, $ignoreFiles)) {
 				$this->io->write("Composer cleaner: Removing $path", true, IOInterface::VERBOSE);
-				$this->fileSystem->remove($path);
+				$this->fileSystem->remove((string) $path);
 				$this->removedCount++;
 			}
 		}


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

Composer\Util\Filesystem::remove() now expects string as $file parameter:
```
In Filesystem.php line 41:
                                                                                                                                                                                                                                 
  [TypeError]                                                                                                                                                                                                                    
  Argument 1 passed to Composer\Util\Filesystem::remove() must be of the type string, object given, called in .../vendor/dg/composer-cleaner/src/ComposerCleaner/Cleaner.php on line 101  
```

BC changes in Composer 2.3.0 release:
https://github.com/composer/composer/commit/6da38f83a0d5acc71793f337b525fa2faff9468e#diff-0257f81fd9bc0572b4399acf6ddae947814cd2340a970838a8649b24caa97530R259
https://github.com/composer/composer/commit/6a466a120a404d1c5d492e5ca715841c491517fc#diff-720233bf29e23e314f9436edd8d3d084b4b63e681eeb4267ec5ac9ac93ff6d4eR1
